### PR TITLE
[IMP][idempierewsc]: agregando importacion req

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,11 @@ along with idempierewsc.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from distutils.core import setup
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+
 
 requirements = parse_requirements('requirements.txt', session=False)
 


### PR DESCRIPTION
para las versión de pip >=10.0.0 no se puede utilizar directamente pip.req
https://stackoverflow.com/questions/25192794/no-module-named-pip-req